### PR TITLE
Alternate Install instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ AWS also offers a similar dashboard in the AWS console, and such data is availab
 ```bash
 go install github.com/leanercloud/aws-ipv4-cost-viewer@latest
 ```
+### OR
+
+```bash
+git clone https://github.com/LeanerCloud/aws-ipv4-cost-viewer
+go run .
+```
+
 
 ## Usage
 


### PR DESCRIPTION
adding install instructions to just download repo and run the program, faced using the commands in README on Apple M2 - hence the PR